### PR TITLE
all: use std::chrono instead of platform specific code

### DIFF
--- a/src/bnet.cpp
+++ b/src/bnet.cpp
@@ -125,7 +125,7 @@ uint32_t CBNET::SetFD(void *fd, void *send_fd, int32_t *nfds)
 
 bool CBNET::Update(void *fd, void *send_fd)
 {
-  const uint32_t Ticks = GetTicks(), Time = GetTime();
+  const uint64_t Ticks = GetTicks(), Time = GetTime();
 
   // we return at the end of each if statement so we don't have to deal with errors related to the order of the if statements
   // that means it might take a few ms longer to complete a task involving multiple steps (in this case, reconnecting) due to blocking or sleeping
@@ -394,7 +394,7 @@ bool CBNET::Update(void *fd, void *send_fd)
     // check if at least one packet is waiting to be sent and if we've waited long enough to prevent flooding
     // this formula has changed many times but currently we wait 1 second if the last packet was "small", 3.5 seconds if it was "medium", and 4 seconds if it was "big"
 
-    uint32_t WaitTicks;
+    uint64_t WaitTicks;
 
     if (m_LastOutPacketSize < 10)
       WaitTicks = 1300;

--- a/src/bnet.h
+++ b/src/bnet.h
@@ -67,14 +67,14 @@ private:
   std::string m_PasswordHashType;           // password hash type for PvPGN users
   uint32_t m_LocaleID;                      // see: http://msdn.microsoft.com/en-us/library/0h88fahh%28VS.85%29.aspx
   uint32_t m_HostCounterID;                 // the host counter ID to identify players from this realm
-  uint32_t m_LastDisconnectedTime;          // GetTime when we were last disconnected from battle.net
-  uint32_t m_LastConnectionAttemptTime;     // GetTime when we last attempted to connect to battle.net
-  uint32_t m_LastNullTime;                  // GetTime when the last null packet was sent for detecting disconnects
-  uint32_t m_LastOutPacketTicks;            // GetTicks when the last packet was sent for the m_OutPackets queue
-  uint32_t m_LastOutPacketSize;             // byte size of the last packet we sent from the m_OutPackets queue
-  uint32_t m_LastAdminRefreshTime;          // GetTime when the admin list was last refreshed from the database
-  uint32_t m_LastBanRefreshTime;            // GetTime when the ban list was last refreshed from the database
-  uint32_t m_ReconnectDelay;                // int32_terval between two consecutive connect attempts
+  uint64_t m_LastDisconnectedTime;          // GetTime when we were last disconnected from battle.net
+  uint64_t m_LastConnectionAttemptTime;     // GetTime when we last attempted to connect to battle.net
+  uint64_t m_LastNullTime;                  // GetTime when the last null packet was sent for detecting disconnects
+  uint64_t m_LastOutPacketTicks;            // GetTicks when the last packet was sent for the m_OutPackets queue
+  uint64_t m_LastOutPacketSize;             // byte size of the last packet we sent from the m_OutPackets queue
+  uint64_t m_LastAdminRefreshTime;          // GetTime when the admin list was last refreshed from the database
+  uint64_t m_LastBanRefreshTime;            // GetTime when the ban list was last refreshed from the database
+  uint64_t m_ReconnectDelay;                // int32_terval between two consecutive connect attempts
   uint8_t m_War3Version;                    // custom warcraft 3 version for PvPGN users
   char m_CommandTrigger;                    // the character prefix to identify commands
   bool m_Exiting;                           // set to true and this class will be deleted next update

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -160,7 +160,7 @@ CGame::~CGame()
   delete m_Stats;
 }
 
-uint32_t CGame::GetNextTimedActionTicks() const
+uint64_t CGame::GetNextTimedActionTicks() const
 {
   // return the number of ticks (ms) until the next "timed action", which for our purposes is the next game update
   // the main Aura++ loop will make sure the next loop update happens at or before this value
@@ -170,7 +170,7 @@ uint32_t CGame::GetNextTimedActionTicks() const
   if (!m_GameLoaded || m_Lagging)
     return 50;
 
-  const uint32_t TicksSinceLastUpdate = GetTicks() - m_LastActionSentTicks;
+  const uint64_t TicksSinceLastUpdate = GetTicks() - m_LastActionSentTicks;
 
   if (TicksSinceLastUpdate > m_Latency - m_LastActionLateBy)
     return 0;
@@ -304,7 +304,7 @@ uint32_t CGame::SetFD(void *fd, void *send_fd, int32_t *nfds)
 
 bool CGame::Update(void *fd, void *send_fd)
 {
-  const uint32_t Time = GetTime(), Ticks = GetTicks();
+  const uint64_t Time = GetTime(), Ticks = GetTicks();
 
   // ping every 5 seconds
   // changed this to ping during game loading as well to hopefully fix some problems with people disconnecting during loading
@@ -435,7 +435,7 @@ bool CGame::Update(void *fd, void *send_fd)
         }
       }
 
-      uint32_t WaitTime = 60;
+      uint64_t WaitTime = 60;
 
       if (UsingGProxy)
         WaitTime = (m_GProxyEmptyActions + 1) * 60;
@@ -989,9 +989,9 @@ void CGame::SendAllActions()
   else
     SendAll(m_Protocol->SEND_W3GS_INCOMING_ACTION(m_Actions, m_Latency));
 
-  const uint32_t Ticks = GetTicks();
-  const uint32_t ActualSendInterval = Ticks - m_LastActionSentTicks;
-  const uint32_t ExpectedSendInterval = m_Latency - m_LastActionLateBy;
+  const uint64_t Ticks = GetTicks();
+  const uint64_t ActualSendInterval = Ticks - m_LastActionSentTicks;
+  const uint64_t ExpectedSendInterval = m_Latency - m_LastActionLateBy;
   m_LastActionLateBy = ActualSendInterval - ExpectedSendInterval;
 
   if (m_LastActionLateBy > m_Latency)
@@ -1081,9 +1081,9 @@ void CGame::EventPlayerDisconnectTimedOut(CGamePlayer *player)
 
     if (GetTime() - player->GetLastGProxyWaitNoticeSentTime() >= 20)
     {
-      uint32_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
+      uint64_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
 
-      if (TimeRemaining > ((uint32_t) m_GProxyEmptyActions + 1) * 60)
+      if (TimeRemaining > ((uint64_t) m_GProxyEmptyActions + 1) * 60)
         TimeRemaining = (m_GProxyEmptyActions + 1) * 60;
 
       SendAllChat(player->GetPID(), "Please wait for me to reconnect (" + to_string(TimeRemaining) + " seconds remain)");
@@ -1120,9 +1120,9 @@ void CGame::EventPlayerDisconnectSocketError(CGamePlayer *player)
 
     if (GetTime() - player->GetLastGProxyWaitNoticeSentTime() >= 20)
     {
-      uint32_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
+      uint64_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
 
-      if (TimeRemaining > ((uint32_t) m_GProxyEmptyActions + 1) * 60)
+      if (TimeRemaining > ((uint64_t) m_GProxyEmptyActions + 1) * 60)
         TimeRemaining = (m_GProxyEmptyActions + 1) * 60;
 
       SendAllChat(player->GetPID(), "Please wait for me to reconnect (" + to_string(TimeRemaining) + " seconds remain)");
@@ -1152,9 +1152,9 @@ void CGame::EventPlayerDisconnectConnectionClosed(CGamePlayer *player)
 
     if (GetTime() - player->GetLastGProxyWaitNoticeSentTime() >= 20)
     {
-      uint32_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
+      uint64_t TimeRemaining = (m_GProxyEmptyActions + 1) * 60 - (GetTime() - m_StartedLaggingTime);
 
-      if (TimeRemaining > ((uint32_t) m_GProxyEmptyActions + 1) * 60)
+      if (TimeRemaining > ((uint64_t) m_GProxyEmptyActions + 1) * 60)
         TimeRemaining = (m_GProxyEmptyActions + 1) * 60;
 
       SendAllChat(player->GetPID(), "Please wait for me to reconnect (" + to_string(TimeRemaining) + " seconds remain)");

--- a/src/game.h
+++ b/src/game.h
@@ -77,26 +77,26 @@ protected:
   uint32_t m_Latency;                           // the number of ms to wait between sending action packets (we queue any received during this time)
   uint32_t m_SyncLimit;                         // the maximum number of packets a player can fall out of sync before starting the lag screen
   uint32_t m_SyncCounter;                       // the number of actions sent so far (for determining if anyone is lagging)
-  uint32_t m_GameTicks;                         // ingame ticks
-  uint32_t m_CreationTime;                      // GetTime when the game was created
-  uint32_t m_LastPingTime;                      // GetTime when the last ping was sent
-  uint32_t m_LastRefreshTime;                   // GetTime when the last game refresh was sent
-  uint32_t m_LastDownloadTicks;                 // GetTicks when the last map download cycle was performed
+  uint64_t m_GameTicks;                         // ingame ticks
+  uint64_t m_CreationTime;                      // GetTime when the game was created
+  uint64_t m_LastPingTime;                      // GetTime when the last ping was sent
+  uint64_t m_LastRefreshTime;                   // GetTime when the last game refresh was sent
+  uint64_t m_LastDownloadTicks;                 // GetTicks when the last map download cycle was performed
   uint32_t m_DownloadCounter;                   // # of map bytes downloaded in the last second
-  uint32_t m_LastDownloadCounterResetTicks;     // GetTicks when the download counter was last reset
-  uint32_t m_LastCountDownTicks;                // GetTicks when the last countdown message was sent
+  uint64_t m_LastDownloadCounterResetTicks;     // GetTicks when the download counter was last reset
+  uint64_t m_LastCountDownTicks;                // GetTicks when the last countdown message was sent
   uint32_t m_CountDownCounter;                  // the countdown is finished when this reaches zero
-  uint32_t m_StartedLoadingTicks;               // GetTicks when the game started loading
+  uint64_t m_StartedLoadingTicks;               // GetTicks when the game started loading
   uint32_t m_StartPlayers;                      // number of players when the game started
-  uint32_t m_LastLagScreenResetTime;            // GetTime when the "lag" screen was last reset
-  uint32_t m_LastActionSentTicks;               // GetTicks when the last action packet was sent
-  uint32_t m_LastActionLateBy;                  // the number of ticks we were late sending the last action packet by
-  uint32_t m_StartedLaggingTime;                // GetTime when the last lag screen started
-  uint32_t m_LastLagScreenTime;                 // GetTime when the last lag screen was active (continuously updated)
-  uint32_t m_LastReservedSeen;                  // GetTime when the last reserved player was seen in the lobby
-  uint32_t m_StartedKickVoteTime;               // GetTime when the kick vote was started
-  uint32_t m_GameOverTime;                      // GetTime when the game was over
-  uint32_t m_LastPlayerLeaveTicks;              // GetTicks when the most recent player left the game
+  uint64_t m_LastLagScreenResetTime;            // GetTime when the "lag" screen was last reset
+  uint64_t m_LastActionSentTicks;               // GetTicks when the last action packet was sent
+  uint64_t m_LastActionLateBy;                  // the number of ticks we were late sending the last action packet by
+  uint64_t m_StartedLaggingTime;                // GetTime when the last lag screen started
+  uint64_t m_LastLagScreenTime;                 // GetTime when the last lag screen was active (continuously updated)
+  uint64_t m_LastReservedSeen;                  // GetTime when the last reserved player was seen in the lobby
+  uint64_t m_StartedKickVoteTime;               // GetTime when the kick vote was started
+  uint64_t m_GameOverTime;                      // GetTime when the game was over
+  uint64_t m_LastPlayerLeaveTicks;              // GetTicks when the most recent player left the game
   uint16_t m_HostPort;                          // the port to host games on
   uint8_t m_GameState;                          // game state, public or private
   uint8_t m_VirtualHostPID;                     // host's PID
@@ -132,14 +132,14 @@ public:
   inline std::string GetCreatorName() const         { return m_CreatorName; }
   inline std::string GetCreatorServer() const       { return m_CreatorServer; }
   inline uint32_t GetHostCounter() const            { return m_HostCounter; }
-  inline uint32_t GetLastLagScreenTime() const      { return m_LastLagScreenTime; }
+  inline uint64_t GetLastLagScreenTime() const      { return m_LastLagScreenTime; }
   inline bool GetLocked() const                     { return m_Locked; }
   inline bool GetCountDownStarted() const           { return m_CountDownStarted; }
   inline bool GetGameLoading() const                { return m_GameLoading; }
   inline bool GetGameLoaded() const                 { return m_GameLoaded; }
   inline bool GetLagging() const                    { return m_Lagging; }
 
-  uint32_t GetNextTimedActionTicks() const;
+  uint64_t GetNextTimedActionTicks() const;
   uint32_t GetSlotsOccupied() const;
   uint32_t GetSlotsOpen() const;
   uint32_t GetNumPlayers() const;

--- a/src/gameplayer.cpp
+++ b/src/gameplayer.cpp
@@ -187,7 +187,7 @@ uint32_t CGamePlayer::GetPing(bool LCPing) const
 
 bool CGamePlayer::Update(void *fd)
 {
-  const uint32_t Time = GetTime();
+  const uint64_t Time = GetTime();
 
   // wait 4 seconds after joining before sending the /whois or /w
   // if we send the /whois too early battle.net may not have caught up with where the player is and return erroneous results

--- a/src/gameplayer.h
+++ b/src/gameplayer.h
@@ -94,16 +94,16 @@ private:
   uint32_t m_TotalPacketsReceived;          // the total number of packets received from the player
   uint32_t m_LeftCode;                      // the code to be sent in W3GS_PLAYERLEAVE_OTHERS for why this player left the game
   uint32_t m_SyncCounter;                   // the number of keepalive packets received from this player
-  uint32_t m_JoinTime;                      // GetTime when the player joined the game (used to delay sending the /whois a few seconds to allow for some lag)
+  uint64_t m_JoinTime;                      // GetTime when the player joined the game (used to delay sending the /whois a few seconds to allow for some lag)
   uint32_t m_LastMapPartSent;               // the last mappart sent to the player (for sending more than one part at a time)
   uint32_t m_LastMapPartAcked;              // the last mappart acknowledged by the player
-  uint32_t m_StartedDownloadingTicks;       // GetTicks when the player started downloading the map
-  uint32_t m_FinishedDownloadingTime;       // GetTime when the player finished downloading the map
-  uint32_t m_FinishedLoadingTicks;          // GetTicks when the player finished loading the game
-  uint32_t m_StartedLaggingTicks;           // GetTicks when the player started laggin
-  uint32_t m_LastGProxyWaitNoticeSentTime;  // GetTime when the last disconnection notice has been sent when using GProxy++
+  uint64_t m_StartedDownloadingTicks;       // GetTicks when the player started downloading the map
+  uint64_t m_FinishedDownloadingTime;       // GetTime when the player finished downloading the map
+  uint64_t m_FinishedLoadingTicks;          // GetTicks when the player finished loading the game
+  uint64_t m_StartedLaggingTicks;           // GetTicks when the player started laggin
+  uint64_t m_LastGProxyWaitNoticeSentTime;  // GetTime when the last disconnection notice has been sent when using GProxy++
   uint32_t m_GProxyReconnectKey;            // the GProxy++ reconnect key
-  uint32_t m_LastGProxyAckTime;             // GetTime when we last acknowledged GProxy++ packet
+  uint64_t m_LastGProxyAckTime;             // GetTime when we last acknowledged GProxy++ packet
   uint8_t m_PID;                            // the player's PID
   bool m_Spoofed;                           // if the player has spoof checked or not
   bool m_Reserved;                          // if the player is reserved (VIP) or not
@@ -144,14 +144,14 @@ public:
   inline std::string GetJoinedRealm() const                           { return m_JoinedRealm; }
   inline uint32_t GetLeftCode() const                                 { return m_LeftCode; }
   inline uint32_t GetSyncCounter() const                              { return m_SyncCounter; }
-  inline uint32_t GetJoinTime() const                                 { return m_JoinTime; }
+  inline uint64_t GetJoinTime() const                                 { return m_JoinTime; }
   inline uint32_t GetLastMapPartSent() const                          { return m_LastMapPartSent; }
   inline uint32_t GetLastMapPartAcked() const                         { return m_LastMapPartAcked; }
-  inline uint32_t GetStartedDownloadingTicks() const                  { return m_StartedDownloadingTicks; }
-  inline uint32_t GetFinishedDownloadingTime() const                  { return m_FinishedDownloadingTime; }
-  inline uint32_t GetFinishedLoadingTicks() const                     { return m_FinishedLoadingTicks; }
-  inline uint32_t GetStartedLaggingTicks() const                      { return m_StartedLaggingTicks; }
-  inline uint32_t GetLastGProxyWaitNoticeSentTime() const             { return m_LastGProxyWaitNoticeSentTime; }
+  inline uint64_t GetStartedDownloadingTicks() const                  { return m_StartedDownloadingTicks; }
+  inline uint64_t GetFinishedDownloadingTime() const                  { return m_FinishedDownloadingTime; }
+  inline uint64_t GetFinishedLoadingTicks() const                     { return m_FinishedLoadingTicks; }
+  inline uint64_t GetStartedLaggingTicks() const                      { return m_StartedLaggingTicks; }
+  inline uint64_t GetLastGProxyWaitNoticeSentTime() const             { return m_LastGProxyWaitNoticeSentTime; }
   inline uint32_t GetGProxyReconnectKey() const                       { return m_GProxyReconnectKey; }
   inline bool GetGProxy() const                                       { return m_GProxy; }
   inline bool GetGProxyDisconnectNoticeSent() const                   { return m_GProxyDisconnectNoticeSent; }
@@ -177,9 +177,9 @@ public:
   inline void SetSyncCounter(uint32_t nSyncCounter)                                    { m_SyncCounter = nSyncCounter; }
   inline void SetLastMapPartSent(uint32_t nLastMapPartSent)                            { m_LastMapPartSent = nLastMapPartSent; }
   inline void SetLastMapPartAcked(uint32_t nLastMapPartAcked)                          { m_LastMapPartAcked = nLastMapPartAcked; }
-  inline void SetStartedDownloadingTicks(uint32_t nStartedDownloadingTicks)            { m_StartedDownloadingTicks = nStartedDownloadingTicks; }
-  inline void SetFinishedDownloadingTime(uint32_t nFinishedDownloadingTime)            { m_FinishedDownloadingTime = nFinishedDownloadingTime; }
-  inline void SetStartedLaggingTicks(uint32_t nStartedLaggingTicks)                    { m_StartedLaggingTicks = nStartedLaggingTicks; }
+  inline void SetStartedDownloadingTicks(uint64_t nStartedDownloadingTicks)            { m_StartedDownloadingTicks = nStartedDownloadingTicks; }
+  inline void SetFinishedDownloadingTime(uint64_t nFinishedDownloadingTime)            { m_FinishedDownloadingTime = nFinishedDownloadingTime; }
+  inline void SetStartedLaggingTicks(uint64_t nStartedLaggingTicks)                    { m_StartedLaggingTicks = nStartedLaggingTicks; }
   inline void SetSpoofed(bool nSpoofed)                                                { m_Spoofed = nSpoofed; }
   inline void SetReserved(bool nReserved)                                              { m_Reserved = nReserved; }
   inline void SetWhoisShouldBeSent(bool nWhoisShouldBeSent)                            { m_WhoisShouldBeSent = nWhoisShouldBeSent; }
@@ -192,7 +192,7 @@ public:
   inline void SetMuted(bool nMuted)                                                    { m_Muted = nMuted; }
   inline void SetLeftMessageSent(bool nLeftMessageSent)                                { m_LeftMessageSent = nLeftMessageSent; }
   inline void SetGProxyDisconnectNoticeSent(bool nGProxyDisconnectNoticeSent)          { m_GProxyDisconnectNoticeSent = nGProxyDisconnectNoticeSent; }
-  inline void SetLastGProxyWaitNoticeSentTime(uint32_t nLastGProxyWaitNoticeSentTime)  { m_LastGProxyWaitNoticeSentTime = nLastGProxyWaitNoticeSentTime; }
+  inline void SetLastGProxyWaitNoticeSentTime(uint64_t nLastGProxyWaitNoticeSentTime)  { m_LastGProxyWaitNoticeSentTime = nLastGProxyWaitNoticeSentTime; }
 
   // processing functions
 

--- a/src/includes.h
+++ b/src/includes.h
@@ -40,8 +40,8 @@ typedef std::pair<uint8_t, std::string> PIDPlayer;
 
 // time
 
-uint32_t GetTime();   // seconds
-uint32_t GetTicks();  // milliseconds
+int64_t GetTime();   // seconds
+int64_t GetTicks();  // milliseconds
 
 #ifdef WIN32
 #define MILLISLEEP( x ) Sleep( x )

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -77,7 +77,7 @@ uint32_t CIRC::SetFD(void *fd, void *send_fd, int32_t *nfds)
 
 bool CIRC::Update(void *fd, void *send_fd)
 {
-  const uint32_t Time = GetTime();
+  const uint64_t Time = GetTime();
 
   if (m_Socket->HasError())
   {
@@ -190,7 +190,7 @@ bool CIRC::Update(void *fd, void *send_fd)
 
 void CIRC::ExtractPackets()
 {
-  const uint32_t Time = GetTime();
+  const uint64_t Time = GetTime();
   string *Recv = m_Socket->GetBytes();
 
   // separate packets using the CRLF delimiter

--- a/src/irc.h
+++ b/src/irc.h
@@ -41,9 +41,9 @@ public:
   std::string m_NicknameCpy;
   std::string m_Username;
   std::string m_Password;
-  uint32_t m_LastConnectionAttemptTime;
-  uint32_t m_LastPacketTime;
-  uint32_t m_LastAntiIdleTime;
+  uint64_t m_LastConnectionAttemptTime;
+  uint64_t m_LastPacketTime;
+  uint64_t m_LastAntiIdleTime;
   uint16_t m_Port;
   int8_t m_CommandTrigger;
   bool m_Exiting;

--- a/src/util.h
+++ b/src/util.h
@@ -61,6 +61,14 @@ inline BYTEARRAY CreateByteArray(uint32_t i, bool reverse)
     return BYTEARRAY { (uint8_t)(i >> 24), (uint8_t)(i >> 16), (uint8_t)(i >> 8), (uint8_t) i };
 }
 
+inline BYTEARRAY CreateByteArray(int64_t i, bool reverse)
+{
+  if (!reverse)
+    return BYTEARRAY { (uint8_t) i, (uint8_t)(i >> 8), (uint8_t)(i >> 16), (uint8_t)(i >> 24) };
+  else
+    return BYTEARRAY { (uint8_t)(i >> 24), (uint8_t)(i >> 16), (uint8_t)(i >> 8), (uint8_t) i };
+}
+
 inline uint16_t ByteArrayToUInt16(const BYTEARRAY &b, bool reverse, uint32_t start = 0)
 {
   if (b.size() < start + 2)
@@ -155,6 +163,11 @@ inline void AppendByteArray(BYTEARRAY &b, uint16_t i, bool reverse)
 }
 
 inline void AppendByteArray(BYTEARRAY &b, uint32_t i, bool reverse)
+{
+  AppendByteArray(b, CreateByteArray(i, reverse));
+}
+
+inline void AppendByteArray(BYTEARRAY &b, int64_t i, bool reverse)
 {
   AppendByteArray(b, CreateByteArray(i, reverse));
 }


### PR DESCRIPTION
This bumps memory usage a bit due to using 64-bit integers but this
means the bot itself can now run more than ~50 days without crashing due
to 32-bit variables overflowing.