### PR TITLE
Add include for cstdint in bnetprotocol.h

### DIFF
--- a/src/bnetprotocol.h
+++ b/src/bnetprotocol.h
@@ -27,6 +27,7 @@
 
 #define BNET_HEADER_CONSTANT 255
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This fix is required to build Aura with make

